### PR TITLE
allow max_volume and volume_constraints both exist for triangle.py

### DIFF
--- a/meshpy/triangle.py
+++ b/meshpy/triangle.py
@@ -154,9 +154,7 @@ def build(mesh_info, verbose=False, refinement_func=None, attributes=False,
 
     if volume_constraints:
         opts += "a"
-        if max_volume:
-            raise ValueError("cannot specify both volume_constraints and max_area")
-    elif max_volume:
+    if max_volume:
         opts += "a%.20f" % max_volume
 
     if refinement_func is not None:


### PR DESCRIPTION
Dear @inducer 

I think it is fine to enbale both `max_volume` and `volume_constraints` in triangle.py as it is in tet.py. So we could set a default (background) area constraints and refine some regional areas via info.regions.resize(n).

Best regards.

benyuan