### PR TITLE
Add write_vtk in meshpy.triangle.MeshInfo

### DIFF
--- a/meshpy/triangle.py
+++ b/meshpy/triangle.py
@@ -61,7 +61,15 @@ class MeshInfo(internals.MeshInfo, MeshInfoBase):
     def dump(self):
         for name in self._constituents:
             dump_array(name, getattr(self, name))
-
+    
+    def write_vtk(self, filename):
+        import pyvtk
+        vtkelements = pyvtk.VtkData(
+            pyvtk.UnstructuredGrid(
+                self.points,
+                triangle=self.elements),
+            "Mesh")
+        vtkelements.tofile(filename)
 
 
 


### PR DESCRIPTION
We add the method for saving the meshpy.triangle.MeshInfo in the ".vtk" format.