### PR TITLE
Exposing voronoi edges and facets.

### DIFF
--- a/doc/tri-tet.rst
+++ b/doc/tri-tet.rst
@@ -285,6 +285,12 @@ Some common notions
     .. attribute:: edge_adjacent_elements
 
         .. versionadded:: 2016.1
+    .. attribute:: voro_edges
+
+        .. versionadded:: 2016.2
+    .. attribute:: voro_facets
+
+        .. versionadded:: 2016.2
     .. attribute:: number_of_point_attributes
     .. attribute:: number_of_element_attributes
 

--- a/src/cpp/wrap_tetgen.cpp
+++ b/src/cpp/wrap_tetgen.cpp
@@ -34,22 +34,25 @@ namespace
       tForeignArray<REAL>                       ElementVolumes; // out
       tForeignArray<int>                        Neighbors; // out
 
-      tForeignArray<tetgenio::facet>      Facets;
-      tForeignArray<int>                  FacetMarkers;
+      tForeignArray<tetgenio::facet>            Facets;
+      tForeignArray<int>                        FacetMarkers;
 
-      tForeignArray<REAL>                 Holes;
-      tForeignArray<REAL>                 Regions;
+      tForeignArray<REAL>                       Holes;
+      tForeignArray<REAL>                       Regions;
 
-      tForeignArray<REAL>                 FacetConstraints;
-      tForeignArray<REAL>                 SegmentConstraints;
+      tForeignArray<REAL>                       FacetConstraints;
+      tForeignArray<REAL>                       SegmentConstraints;
 
-      tForeignArray<int>                  Faces;
-      tForeignArray<int>                  AdjacentElements;
-      tForeignArray<int>                  FaceMarkers;
+      tForeignArray<int>                        Faces;
+      tForeignArray<int>                        AdjacentElements;
+      tForeignArray<int>                        FaceMarkers;
 
-      tForeignArray<int>                  Edges;
-      tForeignArray<int>                  EdgeMarkers;
-      tForeignArray<int>                  EdgeAdjTetList;
+      tForeignArray<int>                        Edges;
+      tForeignArray<int>                        EdgeMarkers;
+      tForeignArray<int>                        EdgeAdjTetList;
+
+      tForeignArray<tetgenio::voroedge>         VoroEdges;
+      tForeignArray<tetgenio::vorofacet>        VoroFacets;
 
     public:
       tMeshInfo()
@@ -80,7 +83,10 @@ namespace
 
           Edges(edgelist, numberofedges, 2),
           EdgeMarkers(edgemarkerlist, numberofedges, 1, &Edges),
-          EdgeAdjTetList(edgeadjtetlist, numberofedges, 1, &Edges)
+          EdgeAdjTetList(edgeadjtetlist, numberofedges, 1, &Edges),
+
+          VoroEdges(vedgelist, numberofvedges, 2),
+          VoroFacets(vfacetlist, numberofvfacets, 2)
       {
         Elements.fixUnit(numberofcorners);
       }
@@ -249,25 +255,30 @@ namespace
         self.polygonlist, self.numberofpolygons);
   }
 
-
-
-
   tForeignArray<REAL> *facet_get_holes(tetgenio::facet &self)
   {
     return new tForeignArray<REAL>(self.holelist, self.numberofholes, 3);
   }
 
 
-
-
-
   tForeignArray<int> *polygon_get_vertices(tetgenio::polygon &self)
   {
     return new tForeignArray<int>(self.vertexlist, self.numberofvertices);
   }
+
+  int *voro_get_edge(tetgenio::voroedge &self)
+  {
+    int edge[2] = { self.v1, self.v2 };
+    return edge;
+  }
+
+  int *voro_get_facet(tetgenio::vorofacet &self)
+  {
+    int facet[2] = { self.c1, self.c2 };
+    return facet;
+  }
+
 }
-
-
 
 
 
@@ -313,6 +324,9 @@ BOOST_PYTHON_MODULE(_tetgen)
       .def_readonly("edges", &cl::Edges)
       .def_readonly("edge_markers", &cl::EdgeMarkers)
       .def_readonly("edge_adjacent_elements", &cl::EdgeAdjTetList)
+
+      .def_readonly("voro_edges", &cl::VoroEdges)
+      .def_readonly("voro_facets", &cl::VoroFacets)
 
       .add_property("number_of_point_attributes",
           &cl::numberOfPointAttributes,
@@ -365,6 +379,22 @@ BOOST_PYTHON_MODULE(_tetgen)
     class_<cl, boost::noncopyable>("Polygon", no_init)
       .add_property("vertices",
           make_function(polygon_get_vertices, manage_new_internal_reference<>()))
+      ;
+  }
+
+  {
+    typedef tetgenio::voroedge cl;
+    class_<cl, boost::noncopyable>("VoroEdge", no_init)
+      .add_property("v",
+          make_function(voro_get_edge, manage_new_internal_reference<>()))
+      ;
+  }
+
+  {
+    typedef tetgenio::vorofacet cl;
+    class_<cl, boost::noncopyable>("VoroFacet", no_init)
+      .add_property("c",
+          make_function(voro_get_facet, manage_new_internal_reference<>()))
       ;
   }
 


### PR DESCRIPTION
Currently doesn't compile, but I think it's an easy fix if you know what you're doing, which I don't :P. Issues with the return type of the 'voro_get_edge' and 'voro_get_facet' functions, seems like a Boost thing. Can you spot the problem?