### PR TITLE
fix in setup for python3, is backward compatible to python2

### DIFF
--- a/aksetup_helper.py
+++ b/aksetup_helper.py
@@ -285,7 +285,7 @@ class ConfigSchema:
             if value is not None:
                 filevars[key] = value
 
-        keys = filevars.keys()
+        keys = list(filevars.keys())
         keys.sort()
 
         outf = open(filename, "w")


### PR DESCRIPTION
python3 makes dict.keys() return an iterator, which cannot then be sorted without first generating a list manually.

Thanks for the package -- very useful!