### PR TITLE
Bundle MinGW runtime DLLs into Windows wheels (delvewheel)

### DIFF
--- a/.github/workflows/wheels.yml
+++ b/.github/workflows/wheels.yml
@@ -44,6 +44,15 @@ jobs:
         uses: pypa/cibuildwheel@v3.4.1
         env:
           CIBW_SKIP: "*-musllinux_i686 *-manylinux_i686 *-win32 cp31?t-*"
+          # Make the Windows wheels self-contained. cibuildwheel repairs Linux
+          # (auditwheel) and macOS (delocate) wheels by default, but does
+          # nothing on Windows. The extension is built with MinGW, so the wheel
+          # otherwise ships without its runtime DLLs (libstdc++-6.dll,
+          # libgcc_s_seh-1.dll) and fails to import on a clean Windows Python
+          # ("DLL load failed while importing _internals"). delvewheel bundles
+          # them. See https://github.com/inducer/meshpy/issues/150
+          CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
+          CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
 
       - uses: actions/upload-artifact@v7
         with:


### PR DESCRIPTION
Fixes #150.

## Problem
cibuildwheel repairs Linux wheels (auditwheel → manylinux) and macOS wheels (delocate) by default, but [does not run a repair step on Windows](https://cibuildwheel.pypa.io/en/stable/options/#repair-wheel-command). The extension is built with MinGW, so the published `win_amd64` wheels ship without their runtime DLLs and fail to import on a clean Windows Python:

```
ImportError: DLL load failed while importing _internals: The specified module could not be found.
```

`_internals.*.pyd` imports `libgcc_s_seh-1.dll` and `libstdc++-6.dll` (confirmed via `pefile`), neither of which is bundled in the wheel or present on a stock Windows Python. This also breaks downstreams — e.g. `pip install anuga`, which depends on meshpy.

## Fix
Add the [documented](https://cibuildwheel.pypa.io/en/stable/options/#repair-wheel-command) cibuildwheel Windows repair step using `delvewheel`, which bundles the dependent DLLs and rewrites the load paths so the wheel is self-contained:

```yaml
CIBW_BEFORE_BUILD_WINDOWS: "pip install delvewheel"
CIBW_REPAIR_WHEEL_COMMAND_WINDOWS: "delvewheel repair -w {dest_dir} {wheel}"
```

The MinGW runtime DLLs are on `PATH` during the build (that's how meson finds gcc), so delvewheel locates and bundles them. Linux and macOS builds are unaffected.

## Verifying
This PR's `Build wheels` run produces the Windows wheels; the repaired wheel should contain the bundled DLLs under `meshpy.libs/` (e.g. `delvewheel` adds `libstdc++-6`, `libgcc_s_seh-1`, `libwinpthread-1`), and `import meshpy.triangle` then works in a clean venv with no MinGW on `PATH`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)